### PR TITLE
[SDFAB-959] Add PFCP session struct to keep track of sessions

### DIFF
--- a/cmd/pfcpsim-client/main.go
+++ b/cmd/pfcpsim-client/main.go
@@ -137,7 +137,7 @@ func parseArgs() {
 	outputF := getopt.StringLong("output-file", 'o', "", "File in which copy from Stdout. Default uses only Stdout")
 	remotePeer := getopt.StringLong("remote-peer-address", 'r', "127.0.0.1", "Address or hostname of the remote peer (PFCP Agent)")
 	upfAddr := getopt.StringLong("upf-address", 'u', defaultUpfN3Address, "Address of the UPF (UP4)")
-	sessionCnt := getopt.IntLong("PFCPClientContext-count", 'c', 1, "Set the amount of sessions to create, starting from 1 (included)")
+	sessionCnt := getopt.IntLong("session-count", 'c', 1, "Set the amount of sessions to create, starting from 1 (included)")
 	ueAddrPool := getopt.StringLong("ue-address-pool", 'e', defaultUeAddressPool, "The IPv4 CIDR prefix from which UE addresses will be generated, incrementally")
 	NodeBAddr := getopt.StringLong("nodeb-address", 'g', defaultGNodeBAddress, "The IPv4 of (g/e)NodeBAddress")
 

--- a/cmd/pfcpsim-client/main.go
+++ b/cmd/pfcpsim-client/main.go
@@ -41,7 +41,7 @@ var (
 
 	sessionCount int
 
-	activeSessions[]*PFCPClientContext
+	activeSessions []*PFCPClientContext
 
 	// Emulates 5G SMF/ 4G SGW
 	globalPFCPSimClient *pfcpsim.PFCPClient
@@ -407,11 +407,11 @@ func createSessions(count int) {
 		}
 
 		activeSessions = append(activeSessions, &PFCPClientContext{
-				session: sess,
-				pdrs:    pdrs,
-				fars:    fars,
-				qers:    qers,
-			},
+			session: sess,
+			pdrs:    pdrs,
+			fars:    fars,
+			qers:    qers,
+		},
 		)
 
 		log.Infof("Created new PFCP session")

--- a/cmd/pfcpsim-client/main.go
+++ b/cmd/pfcpsim-client/main.go
@@ -391,7 +391,7 @@ func createSessions(count int) {
 		}
 
 		// TODO keep track of new session
-		err := globalPFCPSimClient.EstablishSession(pdrs, fars, qers)
+		_, err := globalPFCPSimClient.EstablishSession(pdrs, fars, qers)
 		if err != nil {
 			log.Errorf("Error while establishing sessions: %v", err)
 			return

--- a/cmd/pfcpsim-client/main.go
+++ b/cmd/pfcpsim-client/main.go
@@ -379,7 +379,7 @@ func createSessions(count int) {
 		}
 
 		qers := []*ieLib.IE{
-			// PFCPClientContext QER
+			// session QER
 			session.NewQERBuilder().
 				WithID(sessQerID).
 				WithMethod(session.Create).

--- a/pkg/pfcpsim/pfcp_session.go
+++ b/pkg/pfcpsim/pfcp_session.go
@@ -1,0 +1,24 @@
+package pfcpsim
+
+import "github.com/wmnsk/go-pfcp/ie"
+
+type PFCPSession struct {
+    LocalSEID uint64
+    PeerSEID  uint64
+
+    PDRs []*ie.IE
+    FARs []*ie.IE
+
+    QERs []*ie.IE
+}
+
+func NewSession(localSEID uint64, peerSEID uint64) *PFCPSession{
+    return &PFCPSession{
+        LocalSEID: localSEID, // Updated by PFCPClient when establishing session
+        PeerSEID:  peerSEID,  // Updated later by PFCPClient when received F-SEID IE from peer
+        PDRs:      make([]*ie.IE, 0),
+        FARs:      make([]*ie.IE, 0),
+        QERs:      make([]*ie.IE, 0),
+    }
+
+}

--- a/pkg/pfcpsim/pfcp_session.go
+++ b/pkg/pfcpsim/pfcp_session.go
@@ -3,22 +3,21 @@ package pfcpsim
 import "github.com/wmnsk/go-pfcp/ie"
 
 type PFCPSession struct {
-    LocalSEID uint64
-    PeerSEID  uint64
+	LocalSEID uint64
+	PeerSEID  uint64
 
-    PDRs []*ie.IE
-    FARs []*ie.IE
+	PDRs []*ie.IE
+	FARs []*ie.IE
 
-    QERs []*ie.IE
+	QERs []*ie.IE
 }
 
-func NewSession(localSEID uint64, peerSEID uint64) *PFCPSession{
-    return &PFCPSession{
-        LocalSEID: localSEID, // Updated by PFCPClient when establishing session
-        PeerSEID:  peerSEID,  // Updated later by PFCPClient when received F-SEID IE from peer
-        PDRs:      make([]*ie.IE, 0),
-        FARs:      make([]*ie.IE, 0),
-        QERs:      make([]*ie.IE, 0),
-    }
-
+func NewSession(localSEID uint64, peerSEID uint64) *PFCPSession {
+	return &PFCPSession{
+		LocalSEID: localSEID, // Updated by PFCPClient when establishing session
+		PeerSEID:  peerSEID,  // Updated later by PFCPClient when received F-SEID IE from peer
+		PDRs:      make([]*ie.IE, 0),
+		FARs:      make([]*ie.IE, 0),
+		QERs:      make([]*ie.IE, 0),
+	}
 }

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -372,7 +372,10 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 		return nil, InvalidCauseErr
 	}
 
-	remoteSEID, _ := estResp.UPFSEID.FSEID()
+	remoteSEID, err := estResp.UPFSEID.FSEID()
+	if err != nil {
+		return nil, err
+	}
 	// TODO remove remoteSEIDs slice when session are correctly handled through session struct
 	c.remoteSEIDs = append(c.remoteSEIDs, remoteSEID.SEID)
 

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -379,14 +379,10 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 	// TODO remove remoteSEIDs slice when session are correctly handled through session struct
 	c.remoteSEIDs = append(c.remoteSEIDs, remoteSEID.SEID)
 
-	sess := NewSession()
-	sess.LocalSEID = c.numSessions //FSEID was incremented in SendSessionEstablishmentRequest
-	sess.PeerSEID = remoteSEID.SEID
-
-	// Append sent session rules to new session
-	sess.PDRs = append(sess.PDRs, pdrs...)
-	sess.FARs = append(sess.FARs, fars...)
-	sess.QERs = append(sess.QERs, qers...)
+	sess := &PFCPSession{
+		localSEID: c.numSessions, // numSessions was used to create FSEID in SendSessionEstablishmentRequest
+		peerSEID:  remoteSEID.SEID,
+	}
 
 	return sess, nil
 }

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -379,7 +379,9 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 	// TODO remove remoteSEIDs slice when session are correctly handled through session struct
 	c.remoteSEIDs = append(c.remoteSEIDs, remoteSEID.SEID)
 
-	sess := NewSession(c.numSessions, remoteSEID.SEID)
+	sess := NewSession()
+	sess.LocalSEID = c.numSessions //FSEID was incremented in SendSessionEstablishmentRequest
+	sess.PeerSEID = remoteSEID.SEID
 
 	// Append sent session rules to new session
 	sess.PDRs = append(sess.PDRs, pdrs...)

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -210,7 +210,7 @@ func (c *PFCPClient) SendSessionEstablishmentRequest(pdrs []*ieLib.IE, fars []*i
 	return c.sendMsg(estReq)
 }
 
-func (c *PFCPClient) SendSessionModificationRequest(PeerSEID uint64, pdrs []*ieLib.IE, qers []*ieLib.IE ,fars []*ieLib.IE) error {
+func (c *PFCPClient) SendSessionModificationRequest(PeerSEID uint64, pdrs []*ieLib.IE, qers []*ieLib.IE, fars []*ieLib.IE) error {
 	modifyReq := message.NewSessionModificationRequest(
 		0,
 		0,
@@ -377,6 +377,7 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 
 	return nil
 }
+
 // GetNumActiveSessions returns the number of active sessions.
 func (c *PFCPClient) GetNumActiveSessions() uint64 {
 	return c.numSessions

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -358,7 +358,7 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 	if err != nil {
 		// delete FSEID if session was not established.
 		c.numSessions--
-		return nil,  NewTimeoutExpiredError(err)
+		return nil, NewTimeoutExpiredError(err)
 	}
 
 	estResp, ok := resp.(*message.SessionEstablishmentResponse)

--- a/pkg/pfcpsim/session.go
+++ b/pkg/pfcpsim/session.go
@@ -15,7 +15,7 @@ type PFCPSession struct {
 func NewSession() *PFCPSession {
 	return &PFCPSession{
 		LocalSEID: 0, // Updated by PFCPClient when establishing session
-		PeerSEID:  0,  // Updated later by PFCPClient when received F-SEID IE from peer
+		PeerSEID:  0, // Updated later by PFCPClient when received F-SEID IE from peer
 		PDRs:      make([]*ie.IE, 0),
 		FARs:      make([]*ie.IE, 0),
 		QERs:      make([]*ie.IE, 0),

--- a/pkg/pfcpsim/session.go
+++ b/pkg/pfcpsim/session.go
@@ -1,23 +1,6 @@
 package pfcpsim
 
-import "github.com/wmnsk/go-pfcp/ie"
-
 type PFCPSession struct {
-	LocalSEID uint64
-	PeerSEID  uint64
-
-	PDRs []*ie.IE
-	FARs []*ie.IE
-
-	QERs []*ie.IE
-}
-
-func NewSession() *PFCPSession {
-	return &PFCPSession{
-		LocalSEID: 0, // Updated by PFCPClient when establishing session
-		PeerSEID:  0, // Updated later by PFCPClient when received F-SEID IE from peer
-		PDRs:      make([]*ie.IE, 0),
-		FARs:      make([]*ie.IE, 0),
-		QERs:      make([]*ie.IE, 0),
-	}
+	localSEID uint64
+	peerSEID  uint64
 }


### PR DESCRIPTION
Adding a session struct eases keeping track of established sessions, allowing for more complex operations like session modification.