### PR TITLE
Fix incorrect far-builder. Add WithDstInterface method

### DIFF
--- a/cmd/pfcpsim-client/main.go
+++ b/cmd/pfcpsim-client/main.go
@@ -354,7 +354,6 @@ func createSessions(count int) {
 				WithID(uplinkFarID).
 				WithAction(session.ActionForward).
 				WithMethod(session.Create).
-				MarkAsUplink().
 				BuildFAR(),
 
 			// DownlinkFAR
@@ -364,7 +363,6 @@ func createSessions(count int) {
 				WithMethod(session.Create).
 				WithTEID(downlinkTEID).
 				WithDownlinkIP(nodeBAddress.String()).
-				MarkAsDownlink().
 				BuildFAR(),
 		}
 

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -210,7 +210,7 @@ func (c *PFCPClient) SendSessionEstablishmentRequest(pdrs []*ieLib.IE, fars []*i
 	return c.sendMsg(estReq)
 }
 
-func (c *PFCPClient) SendSessionModificationRequest(PeerSEID uint64, pdrs []*ieLib.IE, qers []*ieLib.IE ,fars []*ieLib.IE) error {
+func (c *PFCPClient) SendSessionModificationRequest(PeerSEID uint64, pdrs []*ieLib.IE, qers []*ieLib.IE, fars []*ieLib.IE) error {
 	modifyReq := message.NewSessionModificationRequest(
 		0,
 		0,
@@ -377,6 +377,7 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 
 	return nil
 }
+
 // GetNumActiveSessions returns the number of active sessions.
 func (c *PFCPClient) GetNumActiveSessions() uint64 {
 	return c.numSessions


### PR DESCRIPTION
Far builder should enable the user to set the destination Interface, as described in section 8.2.24 [PFCP specifications](https://www.etsi.org/deliver/etsi_ts/129200_129299/129244/16.04.00_60/ts_129244v160400p.pdf)