### PR TITLE
Add first unit test and CI job

### DIFF
--- a/.github/workflows/run-unit-test.yml
+++ b/.github/workflows/run-unit-test.yml
@@ -1,0 +1,18 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  unit-test-pfcpiface:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2.4.0
+      - uses: actions/setup-go@v2
+
+      - name: Run unit tests for PFCPSim
+        run: |
+          make test

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # Copyright 2022 Open Networking Foundation
 
 .idea/
+.coverage/
 output
 *.pyc
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,10 @@ build-pfcpsim-client:
 
 golint:
 	@docker run --rm -v $(CURDIR):/app -w /app/pkg/pfcpsim golangci/golangci-lint:latest golangci-lint run -v --config /app/.golangci.yml
+
+.coverage:
+	rm -rf $(CURDIR)/.coverage
+	mkdir -p $(CURDIR)/.coverage
+
+test: .coverage
+	go test	-race -coverprofile=.coverage/coverage-unit.txt -covermode=atomic -v ./...

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/c-robinson/iplib v1.0.3
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.2.2
 	github.com/wmnsk/go-pfcp v0.0.14
 )

--- a/pkg/pfcpsim/session/far_builder_test.go
+++ b/pkg/pfcpsim/session/far_builder_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestFARBuilderShouldPanic(t *testing.T) {
-
 	assert.Panics(t, func() {
 		NewFARBuilder().
 			WithMethod(Create).
@@ -32,5 +31,4 @@ func TestFARBuilderShouldPanic(t *testing.T) {
 			WithTEID(100).
 			BuildFAR()
 	})
-
 }

--- a/pkg/pfcpsim/session/far_builder_test.go
+++ b/pkg/pfcpsim/session/far_builder_test.go
@@ -1,0 +1,36 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFARBuilderShouldPanic(t *testing.T) {
+
+	assert.Panics(t, func() {
+		NewFARBuilder().
+			WithMethod(Create).
+			WithAction(ActionDrop).
+			BuildFAR()
+	})
+
+	// Providing partial parameters (DownlinkIP without providing TEID)
+	assert.Panics(t, func() {
+		NewFARBuilder().WithMethod(Create).
+			WithID(1).
+			WithAction(ActionDrop).
+			WithDownlinkIP("10.0.0.1").
+			BuildFAR()
+	})
+
+	// Providing partial parameters (TEID without providing DownlinkIP)
+	assert.Panics(t, func() {
+		NewFARBuilder().WithMethod(Create).
+			WithID(2).
+			WithAction(ActionDrop).
+			WithTEID(100).
+			BuildFAR()
+	})
+
+}

--- a/pkg/pfcpsim/session/far_builder_test.go
+++ b/pkg/pfcpsim/session/far_builder_test.go
@@ -4,31 +4,45 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/wmnsk/go-pfcp/ie"
 )
 
 func TestFARBuilderShouldPanic(t *testing.T) {
-	assert.Panics(t, func() {
-		NewFARBuilder().
-			WithMethod(Create).
-			WithAction(ActionDrop).
-			BuildFAR()
-	})
+	type testCase struct {
+		input *farBuilder
+		expected *ie.IE
+		description string
+	}
 
-	// Providing partial parameters (DownlinkIP without providing TEID)
-	assert.Panics(t, func() {
-		NewFARBuilder().WithMethod(Create).
-			WithID(1).
-			WithAction(ActionDrop).
-			WithDownlinkIP("10.0.0.1").
-			BuildFAR()
-	})
-
-	// Providing partial parameters (TEID without providing DownlinkIP)
-	assert.Panics(t, func() {
-		NewFARBuilder().WithMethod(Create).
+	for _, scenario := range []testCase{
+		{
+			input: NewFARBuilder().
+				WithMethod(Create).
+				WithAction(ActionDrop),
+			expected: nil,
+			description: "Invalid FAR: No ID provided",
+		},
+		{
+			input: NewFARBuilder().
+				WithMethod(Create).
 			WithID(2).
 			WithAction(ActionDrop).
-			WithTEID(100).
-			BuildFAR()
-	})
+			WithTEID(100),
+
+			expected: nil,
+			description: "Invalid FAR: Providing TEID without DownlinkIP",
+		},
+		{
+			input: NewFARBuilder().WithMethod(Create).
+				WithID(1).
+				WithAction(ActionDrop).
+				WithDownlinkIP("10.0.0.1"),
+			expected: nil,
+			description: "Invalid FAR: Providing DownlinkIP without TEID",
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			assert.Panics(t, func() {scenario.input.BuildFAR()} )
+		})
+	}
 }

--- a/pkg/pfcpsim/session/far_builder_test.go
+++ b/pkg/pfcpsim/session/far_builder_test.go
@@ -4,13 +4,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/wmnsk/go-pfcp/ie"
 )
 
 func TestFARBuilderShouldPanic(t *testing.T) {
 	type testCase struct {
-		input *farBuilder
-		expected *ie.IE
+		input       *farBuilder
+		expected    *farBuilder
 		description string
 	}
 
@@ -19,30 +18,42 @@ func TestFARBuilderShouldPanic(t *testing.T) {
 			input: NewFARBuilder().
 				WithMethod(Create).
 				WithAction(ActionDrop),
-			expected: nil,
+			expected: &farBuilder{
+				method:      Create,
+				applyAction: ActionDrop,
+			},
 			description: "Invalid FAR: No ID provided",
 		},
 		{
 			input: NewFARBuilder().
 				WithMethod(Create).
-			WithID(2).
-			WithAction(ActionDrop).
-			WithTEID(100),
+				WithID(2).
+				WithAction(ActionDrop).
+				WithTEID(100),
 
-			expected: nil,
+			expected: &farBuilder{
+				farID:       2,
+				applyAction: ActionDrop,
+				teid:        100,
+			},
 			description: "Invalid FAR: Providing TEID without DownlinkIP",
 		},
 		{
 			input: NewFARBuilder().WithMethod(Create).
 				WithID(1).
-				WithAction(ActionDrop).
+				WithAction(ActionForward).
 				WithDownlinkIP("10.0.0.1"),
-			expected: nil,
+			expected: &farBuilder{
+				farID:       1,
+				applyAction: ActionForward,
+				downlinkIP:  "10.0.0.1",
+			},
 			description: "Invalid FAR: Providing DownlinkIP without TEID",
 		},
 	} {
 		t.Run(scenario.description, func(t *testing.T) {
-			assert.Panics(t, func() {scenario.input.BuildFAR()} )
+			assert.Panics(t, func() { scenario.input.BuildFAR() })
+			assert.Equal(t, scenario.input, scenario.expected)
 		})
 	}
 }


### PR DESCRIPTION
PR's aim is to provide an initial unit test for far_builder and add a CI job executing unit tests for `pfcpsim`