### PR TITLE
Use correct forwarding IE when using create FAR and update FAR

### DIFF
--- a/pkg/pfcpsim/session/far_builder.go
+++ b/pkg/pfcpsim/session/far_builder.go
@@ -63,14 +63,17 @@ func (b *farBuilder) validate() {
 func (b *farBuilder) BuildFAR() *ie.IE {
 	b.validate()
 
-	createFunc := ie.NewCreateFAR
-	if b.method == Update {
-		createFunc = ie.NewUpdateFAR
-	}
-
 	updateFwdParams := ie.NewForwardingParameters(
 		ie.NewDestinationInterface(b.dstInterface),
 	)
+
+	createFunc := ie.NewCreateFAR
+	if b.method == Update {
+		createFunc = ie.NewUpdateFAR
+		updateFwdParams = ie.NewUpdateForwardingParameters(
+			ie.NewDestinationInterface(b.dstInterface),
+		)
+	}
 
 	if b.downlinkIP != "" && b.teid != 0 {
 		updateFwdParams.Add(


### PR DESCRIPTION
PR's aim is to fix the FAR builder to use the correct IE when using `ie.CreateFAR` and `ie.UpdateFAR`.
as described in section 7.5.4.3 of [PFCP specs](https://www.etsi.org/deliver/etsi_ts/129200_129299/129244/16.04.00_60/ts_129244v160400p.pdf), `UpdateForwardingParameters` should be used when creating a UpdateFAR.