### PR TITLE
Add ability to override standard PFCP port

### DIFF
--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -129,7 +129,7 @@ func (c *PFCPClient) ConnectN4(remoteAddr string) error {
 
 	if host, port, err := net.SplitHostPort(remoteAddr); err == nil {
 		// remoteAddr contains also a port. Use provided port instead of PFCPStandardPort
-		raddr, err = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, port))
+		raddr, err = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%s", host, port))
 		if err != nil {
 			return err
 		}

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -127,6 +127,14 @@ func (c *PFCPClient) ConnectN4(remoteAddr string) error {
 		return err
 	}
 
+	if host, port, err := net.SplitHostPort(remoteAddr); err == nil {
+		// remoteAddr contains also a port. Use provided port instead of PFCPStandardPort
+		raddr, err = net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", host, port))
+		if err != nil {
+			return err
+		}
+	}
+
 	conn, err := net.DialUDP("udp", nil, raddr)
 	if err != nil {
 		return err


### PR DESCRIPTION
PR's aim is to give users the ability to set the remote peer's port other then the standard PFCP port (8805)