### PR TITLE
[SDFAB-1031] Add ListenN4 method to allow UP initiated associations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,7 @@ run:
   timeout: 10m
   skip-files:
     - ".*\\.pb\\.go"
-    - "*_test.go"
+    - ".*\\_test\\.go"
   skip-dirs-use-default: true
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ run:
   timeout: 10m
   skip-files:
     - ".*\\.pb\\.go"
+    - "*_test.go"
   skip-dirs-use-default: true
 
 linters:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,6 @@ require (
 	github.com/c-robinson/iplib v1.0.3
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.7.0
 	github.com/wmnsk/go-pfcp v0.0.14
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/c-robinson/iplib v1.0.3 h1:NG0UF0GoEsrC1/vyfX1Lx2Ss7CySWl3KqqXh3q4DdPU=
 github.com/c-robinson/iplib v1.0.3/go.mod h1:i3LuuFL1hRT5gFpBRnEydzw8R6yhGkF4szNDIbF8pgo=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
@@ -12,11 +13,17 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/wmnsk/go-pfcp v0.0.14 h1:PMX7zKZYHaRM8qgjle45a/yis4q9hOAwRTfBMt+o7U4=
 github.com/wmnsk/go-pfcp v0.0.14/go.mod h1:QKYWo1Wac4hc1Ut1YeaPKxcYUf8oHBZyqODJC6VAPBI=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/pfcpsim/errors.go
+++ b/pkg/pfcpsim/errors.go
@@ -52,3 +52,10 @@ func NewInvalidResponseError(err ...error) *pfcpSimError {
 		error:   err,
 	}
 }
+
+func NewInvalidRequestError(err ...error) *pfcpSimError {
+	return &pfcpSimError{
+		message: "Invalid request received",
+		error:   err,
+	}
+}

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -127,7 +127,7 @@ func (c *PFCPClient) ListenN4() error {
 	if err != nil {
 		return err
 	}
-	// Expect a request in 10 seconds, otherwise close connection.
+	// Expect a request in 10 seconds.
 	if err = conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
 		return err
 	}

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -137,15 +137,17 @@ func (c *PFCPClient) ListenN4() error {
 		return NewInvalidRequestError()
 	}
 
+	// use local connection to send response
+	c.conn = conn
+
 	err = c.SendAssociationSetupResponse()
 	if err != nil {
+		// clear connection in case of error
+		c.conn = nil
 		return err
 	}
-
 	// Assuming UP received the response, association is now complete.
 	go c.receiveFromN4()
-
-	c.conn = conn
 
 	return nil
 }

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -131,7 +131,14 @@ func (c *PFCPClient) ListenN4() error {
 	buf := make([]byte, 1500)
 	// read directly from connection and expect an Association Setup Request
 	n, _, err := conn.ReadFrom(buf)
+	if err != nil {
+		return err
+	}
+
 	msg, err := message.Parse(buf[:n])
+	if err != nil {
+		return err
+	}
 
 	if _, ok := msg.(*message.AssociationSetupRequest); !ok {
 		return NewInvalidRequestError()

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -95,8 +95,6 @@ func (c *PFCPClient) sendMsg(msg message.Message) error {
 	}
 
 	if c.remoteAddr != "" {
-		// Connection does not contain remote address when established using ListenN4.
-		// remoteAddr was set when receiving
 		rAddr, err := net.ResolveUDPAddr("udp", c.remoteAddr)
 		if err != nil {
 			return err
@@ -164,7 +162,7 @@ func (c *PFCPClient) ListenN4() error {
 		return NewInvalidRequestError()
 	}
 
-	// Save remote address when connection was established while listening
+	// Save remote address when connection is established while listening
 	c.remoteAddr = remoteAddr.String()
 	c.conn = conn
 
@@ -174,12 +172,6 @@ func (c *PFCPClient) ListenN4() error {
 		c.conn = nil
 		return err
 	}
-
-	// Remove deadline before starting receiveFromN4's goroutine
-	//err = c.conn.SetDeadline(time.Time{})
-	//if err != nil {
-	//	return err
-	//}
 
 	ctx, cancelFunc := context.WithCancel(c.ctx)
 	c.cancelHeartbeats = cancelFunc
@@ -428,7 +420,6 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 	if !c.isAssociationActive {
 		return nil, NewAssociationInactiveError()
 	}
-
 	err := c.SendSessionEstablishmentRequest(pdrs, fars, qers)
 	if err != nil {
 		return nil, err

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -42,7 +42,7 @@ type PFCPClient struct {
 	seqNumLock     sync.Mutex
 
 	localAddr string
-	// remoteAddr is needed when Association is performed by the UP
+	// remoteAddr is needed when association is performed by the UP
 	remoteAddr string
 	conn       *net.UDPConn
 }
@@ -99,6 +99,7 @@ func (c *PFCPClient) sendMsg(msg message.Message) error {
 		if err != nil {
 			return err
 		}
+
 		if _, err := c.conn.WriteToUDP(b, rAddr); err != nil {
 			return err
 		}
@@ -420,6 +421,7 @@ func (c *PFCPClient) EstablishSession(pdrs []*ieLib.IE, fars []*ieLib.IE, qers [
 	if !c.isAssociationActive {
 		return nil, NewAssociationInactiveError()
 	}
+
 	err := c.SendSessionEstablishmentRequest(pdrs, fars, qers)
 	if err != nil {
 		return nil, err

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -147,10 +147,6 @@ func (c *PFCPClient) ListenN4() error {
 	n, remoteAddr, err := conn.ReadFromUDP(buf)
 
 	if err != nil {
-		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
-			return NewTimeoutExpiredError(netErr)
-		}
-
 		return err
 	}
 

--- a/pkg/pfcpsim/pfcpsim.go
+++ b/pkg/pfcpsim/pfcpsim.go
@@ -121,6 +121,20 @@ func (c *PFCPClient) receiveFromN4() {
 	}
 }
 
+// ListenN4 allows for UP initiated PFCP associations.
+func (c *PFCPClient) ListenN4() error {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.ParseIP("0.0.0.0"), Port: PFCPStandardPort})
+	if err != nil {
+		return err
+	}
+
+	c.conn = conn
+
+	go c.receiveFromN4()
+
+	return nil
+}
+
 func (c *PFCPClient) ConnectN4(remoteAddr string) error {
 	raddr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", remoteAddr, PFCPStandardPort))
 	if err != nil {

--- a/pkg/pfcpsim/pfcpsim_test.go
+++ b/pkg/pfcpsim/pfcpsim_test.go
@@ -1,3 +1,6 @@
+//go:build !race || ignore
+// +build !race ignore
+
 /*
  * SPDX-License-Identifier: Apache-2.0
  * Copyright 2022 Open Networking Foundation
@@ -23,8 +26,9 @@ func Test_ListenN4(t *testing.T) {
 
 	wg.Add(1)
 	go func(wg *sync.WaitGroup) {
-		// Start CP in goroutine, awaiting for UP to start association
+		// Start CP in goroutine, awaiting UP to start association
 		defer wg.Done()
+
 		err := CPSim.ListenN4()
 		require.NoError(t, err)
 	}(wg)
@@ -41,6 +45,7 @@ func Test_ListenN4(t *testing.T) {
 		defer wg.Done()
 		// function that mocks a UPF that answers to a session establishment request
 		buf := make([]byte, 1500)
+
 		for {
 			n, err := upfDial.Read(buf)
 			require.NoError(t, err)
@@ -49,7 +54,6 @@ func Test_ListenN4(t *testing.T) {
 			require.NoError(t, err)
 
 			if _, ok := msg.(*message.SessionEstablishmentRequest); ok {
-
 				mockResponse := message.NewSessionEstablishmentResponse(
 					0,
 					0,
@@ -68,7 +72,6 @@ func Test_ListenN4(t *testing.T) {
 				return
 			}
 		}
-
 	}(wg)
 
 	assocReq := message.NewAssociationSetupRequest(

--- a/pkg/pfcpsim/pfcpsim_test.go
+++ b/pkg/pfcpsim/pfcpsim_test.go
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright 2022 Open Networking Foundation
+ */
+
+package pfcpsim
+
+import (
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	ieLib "github.com/wmnsk/go-pfcp/ie"
+	"github.com/wmnsk/go-pfcp/message"
+)
+
+func Test_ListenN4(t *testing.T) {
+	wg := new(sync.WaitGroup)
+	CPSim := NewPFCPClient("127.0.0.1")
+
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		// Start CP in goroutine, awaiting for UP to start association
+		defer wg.Done()
+		err := CPSim.ListenN4()
+		require.NoError(t, err)
+	}(wg)
+
+	// wait for CPSim to start listening
+	time.Sleep(time.Millisecond * 50)
+
+	// emulate UPF starting a PFCP association
+	upfDial, err := net.Dial("udp", fmt.Sprintf(":%v", PFCPStandardPort))
+	require.NoError(t, err)
+
+	wg.Add(1)
+	go func(wg *sync.WaitGroup) {
+		defer wg.Done()
+		// function that mocks a UPF that answers to a session establishment request
+		buf := make([]byte, 1500)
+		for {
+			n, err := upfDial.Read(buf)
+			require.NoError(t, err)
+
+			msg, err := message.Parse(buf[:n])
+			require.NoError(t, err)
+
+			if _, ok := msg.(*message.SessionEstablishmentRequest); ok {
+
+				mockResponse := message.NewSessionEstablishmentResponse(
+					0,
+					0,
+					999,
+					1,
+					0,
+					ieLib.NewFSEID(998, net.ParseIP("127.0.0.1"), nil),
+					ieLib.NewCause(ieLib.CauseRequestAccepted),
+				)
+
+				b, _ := mockResponse.Marshal()
+
+				_, err = upfDial.Write(b)
+				require.NoError(t, err)
+
+				return
+			}
+		}
+
+	}(wg)
+
+	assocReq := message.NewAssociationSetupRequest(
+		1,
+		ieLib.NewRecoveryTimeStamp(time.Now()),
+		ieLib.NewNodeID("127.0.0.1", "", ""),
+	)
+
+	marshal, _ := assocReq.Marshal()
+
+	_, err = upfDial.Write(marshal)
+	require.NoError(t, err)
+
+	// Let CPSim process the association request
+	time.Sleep(time.Millisecond * 50)
+	// CP Establish a fake session.
+	_, err = CPSim.EstablishSession(nil, nil, nil)
+	require.NoError(t, err)
+
+	wg.Wait()
+}


### PR DESCRIPTION
- make golint skip test files
- Add `ListenN4()` method to allow UP to start association
- Add unit test for `ListenN4()`

Should enable the implementation of integrations tests, as described here: https://github.com/omec-project/upf-epc/issues/453