### PR TITLE
Fix modify session

### DIFF
--- a/internal/pfcpsim/server.go
+++ b/internal/pfcpsim/server.go
@@ -246,14 +246,16 @@ func (P pfcpSimService) ModifySession(ctx context.Context, request *pb.ModifySes
 		return &pb.Response{}, status.Error(codes.Aborted, err.Error())
 	}
 
-	actions := session.ActionForward
+	var actions uint8
 
-	if request.NotifyCPFlag {
+	if request.BufferFlag || request.NotifyCPFlag {
+		// We currently support only both flags set
 		actions |= session.ActionNotify
-	}
-
-	if request.BufferFlag {
 		actions |= session.ActionBuffer
+	} else {
+		// If no flag was passed, default action is Forward
+		// TODO make actions to be configurable by cli
+		actions |= session.ActionForward
 	}
 
 	for i := baseID; i < (count*2 + baseID); i = i + 2 {

--- a/internal/pfcpsim/server.go
+++ b/internal/pfcpsim/server.go
@@ -254,7 +254,7 @@ func (P pfcpSimService) ModifySession(ctx context.Context, request *pb.ModifySes
 		actions |= session.ActionBuffer
 	} else {
 		// If no flag was passed, default action is Forward
-		// TODO make actions to be configurable by cli
+		// TODO make actions configurable by cli
 		actions |= session.ActionForward
 	}
 

--- a/internal/pfcpsim/server.go
+++ b/internal/pfcpsim/server.go
@@ -246,7 +246,7 @@ func (P pfcpSimService) ModifySession(ctx context.Context, request *pb.ModifySes
 		return &pb.Response{}, status.Error(codes.Aborted, err.Error())
 	}
 
-	var actions uint8
+	actions := uint8(0)
 
 	if request.BufferFlag || request.NotifyCPFlag {
 		// We currently support only both flags set

--- a/internal/pfcpsim/server.go
+++ b/internal/pfcpsim/server.go
@@ -246,7 +246,7 @@ func (P pfcpSimService) ModifySession(ctx context.Context, request *pb.ModifySes
 		return &pb.Response{}, status.Error(codes.Aborted, err.Error())
 	}
 
-	actions := uint8(0)
+	var actions uint8 = 0
 
 	if request.BufferFlag || request.NotifyCPFlag {
 		// We currently support only both flags set
@@ -254,7 +254,6 @@ func (P pfcpSimService) ModifySession(ctx context.Context, request *pb.ModifySes
 		actions |= session.ActionBuffer
 	} else {
 		// If no flag was passed, default action is Forward
-		// TODO make actions configurable by cli
 		actions |= session.ActionForward
 	}
 

--- a/internal/pfcpsim/server.go
+++ b/internal/pfcpsim/server.go
@@ -235,7 +235,7 @@ func (P pfcpSimService) ModifySession(ctx context.Context, request *pb.ModifySes
 		return &pb.Response{}, status.Error(codes.Aborted, "Server is not configured")
 	}
 
-	// TODO handle buffer, notifyCP flags and 5G as well
+	// TODO add 5G mode
 	baseID := int(request.BaseID)
 	count := int(request.Count)
 	nodeBaddress := request.NodeBAddress


### PR DESCRIPTION
When modifying a session, only certain flags can be passed to NewApplyAction IE.

Fixes the ActionForward flag set, while setting also Buffer and NotifyCP flags