### PR TITLE
Fix incorrect disassociate RPC call and correctly handle gRPC connections

### DIFF
--- a/internal/pfcpctl/commands/helpers.go
+++ b/internal/pfcpctl/commands/helpers.go
@@ -11,12 +11,21 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func connect() (pb.PFCPSimClient, *grpc.ClientConn) {
+var conn *grpc.ClientConn
+
+func connect() pb.PFCPSimClient {
 	// Create an insecure gRPC Channel
-	conn, err := grpc.Dial(config.GlobalConfig.Server, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	var err error
+	conn, err = grpc.Dial(config.GlobalConfig.Server, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("Error dialing %v: %v", config.GlobalConfig.Server, err)
 	}
 
-	return pb.NewPFCPSimClient(conn), conn
+	return pb.NewPFCPSimClient(conn)
+}
+
+func disconnect() {
+	if conn != nil {
+		conn.Close()
+	}
 }

--- a/internal/pfcpctl/commands/helpers.go
+++ b/internal/pfcpctl/commands/helpers.go
@@ -11,12 +11,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-func connect() pb.PFCPSimClient {
+func connect() (pb.PFCPSimClient, *grpc.ClientConn) {
 	// Create an insecure gRPC Channel
 	conn, err := grpc.Dial(config.GlobalConfig.Server, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		log.Fatalf("Error dialing %v: %v", config.GlobalConfig.Server, err)
 	}
 
-	return pb.NewPFCPSimClient(conn)
+	return pb.NewPFCPSimClient(conn), conn
 }

--- a/internal/pfcpctl/commands/services.go
+++ b/internal/pfcpctl/commands/services.go
@@ -35,6 +35,7 @@ func (c *configureRemoteAddresses) Execute(args []string) error {
 		UpfN3Address:      c.N3InterfaceAddress,
 		RemotePeerAddress: c.RemotePeerAddress,
 	})
+
 	if err != nil {
 		log.Fatalf("Error while configuring remote addresses: %v", err)
 	}
@@ -60,7 +61,7 @@ func (c *associate) Execute(args []string) error {
 func (c *disassociate) Execute(args []string) error {
 	client := connect()
 
-	res, err := client.Associate(context.Background(), &pb.EmptyRequest{})
+	res, err := client.Disassociate(context.Background(), &pb.EmptyRequest{})
 	if err != nil {
 		log.Fatalf("Error while disassociating: %v", err)
 	}

--- a/internal/pfcpctl/commands/services.go
+++ b/internal/pfcpctl/commands/services.go
@@ -29,7 +29,8 @@ func RegisterServiceCommands(parser *flags.Parser) {
 }
 
 func (c *configureRemoteAddresses) Execute(args []string) error {
-	client := connect()
+	client, conn := connect()
+	defer conn.Close()
 
 	res, err := client.Configure(context.Background(), &pb.ConfigureRequest{
 		UpfN3Address:      c.N3InterfaceAddress,
@@ -46,7 +47,8 @@ func (c *configureRemoteAddresses) Execute(args []string) error {
 }
 
 func (c *associate) Execute(args []string) error {
-	client := connect()
+	client, conn := connect()
+	defer conn.Close()
 
 	res, err := client.Associate(context.Background(), &pb.EmptyRequest{})
 	if err != nil {
@@ -59,7 +61,8 @@ func (c *associate) Execute(args []string) error {
 }
 
 func (c *disassociate) Execute(args []string) error {
-	client := connect()
+	client, conn := connect()
+	defer conn.Close()
 
 	res, err := client.Disassociate(context.Background(), &pb.EmptyRequest{})
 	if err != nil {

--- a/internal/pfcpctl/commands/services.go
+++ b/internal/pfcpctl/commands/services.go
@@ -18,7 +18,6 @@ type configureRemoteAddresses struct {
 	N3InterfaceAddress string `short:"n" long:"n3-addr" default:"" description:"The IPv4 address of the UPF's N3 interface"`
 }
 
-
 type serviceOptions struct {
 	Associate    associate                `command:"associate"`
 	Disassociate disassociate             `command:"disassociate"`

--- a/internal/pfcpctl/commands/services.go
+++ b/internal/pfcpctl/commands/services.go
@@ -29,8 +29,8 @@ func RegisterServiceCommands(parser *flags.Parser) {
 }
 
 func (c *configureRemoteAddresses) Execute(args []string) error {
-	client, conn := connect()
-	defer conn.Close()
+	client := connect()
+	defer disconnect()
 
 	res, err := client.Configure(context.Background(), &pb.ConfigureRequest{
 		UpfN3Address:      c.N3InterfaceAddress,
@@ -47,8 +47,8 @@ func (c *configureRemoteAddresses) Execute(args []string) error {
 }
 
 func (c *associate) Execute(args []string) error {
-	client, conn := connect()
-	defer conn.Close()
+	client := connect()
+	defer disconnect()
 
 	res, err := client.Associate(context.Background(), &pb.EmptyRequest{})
 	if err != nil {
@@ -61,8 +61,8 @@ func (c *associate) Execute(args []string) error {
 }
 
 func (c *disassociate) Execute(args []string) error {
-	client, conn := connect()
-	defer conn.Close()
+	client := connect()
+	defer disconnect()
 
 	res, err := client.Disassociate(context.Background(), &pb.EmptyRequest{})
 	if err != nil {

--- a/internal/pfcpctl/commands/sessions.go
+++ b/internal/pfcpctl/commands/sessions.go
@@ -56,7 +56,8 @@ func (s *sessionCreate) Execute(args []string) error {
 		log.Fatalf("QFI cannot be greater than 64. Provided QFI: %v", s.Args.QFI)
 	}
 
-	client := connect()
+	client, conn := connect()
+	defer conn.Close()
 
 	res, err := client.CreateSession(context.Background(), &pb.CreateSessionRequest{
 		Count:         int32(s.Args.Count),
@@ -77,7 +78,8 @@ func (s *sessionCreate) Execute(args []string) error {
 }
 
 func (s *sessionModify) Execute(args []string) error {
-	client := connect()
+	client, conn := connect()
+	defer conn.Close()
 
 	res, err := client.ModifySession(context.Background(), &pb.ModifySessionRequest{
 		Count:         int32(s.Args.Count),
@@ -98,7 +100,8 @@ func (s *sessionModify) Execute(args []string) error {
 }
 
 func (s *sessionDelete) Execute(args []string) error {
-	client := connect()
+	client, conn := connect()
+	defer conn.Close()
 
 	res, err := client.DeleteSession(context.Background(), &pb.DeleteSessionRequest{
 		Count:  int32(s.Args.Count),

--- a/internal/pfcpctl/commands/sessions.go
+++ b/internal/pfcpctl/commands/sessions.go
@@ -68,7 +68,7 @@ func (s *sessionCreate) Execute(args []string) error {
 	})
 
 	if err != nil {
-		log.Fatalf("Error while associating: %v", err)
+		log.Fatalf("Error while creating sessions: %v", err)
 	}
 
 	log.Infof(res.Message)
@@ -89,7 +89,7 @@ func (s *sessionModify) Execute(args []string) error {
 	})
 
 	if err != nil {
-		log.Fatalf("Error while associating: %v", err)
+		log.Fatalf("Error while modifying sessions: %v", err)
 	}
 
 	log.Infof(res.Message)
@@ -105,7 +105,7 @@ func (s *sessionDelete) Execute(args []string) error {
 		BaseID: int32(s.Args.BaseID),
 	})
 	if err != nil {
-		log.Fatalf("Error while associating: %v", err)
+		log.Fatalf("Error while deleting sessions: %v", err)
 	}
 
 	log.Infof(res.Message)

--- a/internal/pfcpctl/commands/sessions.go
+++ b/internal/pfcpctl/commands/sessions.go
@@ -56,8 +56,8 @@ func (s *sessionCreate) Execute(args []string) error {
 		log.Fatalf("QFI cannot be greater than 64. Provided QFI: %v", s.Args.QFI)
 	}
 
-	client, conn := connect()
-	defer conn.Close()
+	client := connect()
+	defer disconnect()
 
 	res, err := client.CreateSession(context.Background(), &pb.CreateSessionRequest{
 		Count:         int32(s.Args.Count),
@@ -78,8 +78,8 @@ func (s *sessionCreate) Execute(args []string) error {
 }
 
 func (s *sessionModify) Execute(args []string) error {
-	client, conn := connect()
-	defer conn.Close()
+	client := connect()
+	defer disconnect()
 
 	res, err := client.ModifySession(context.Background(), &pb.ModifySessionRequest{
 		Count:         int32(s.Args.Count),
@@ -100,8 +100,8 @@ func (s *sessionModify) Execute(args []string) error {
 }
 
 func (s *sessionDelete) Execute(args []string) error {
-	client, conn := connect()
-	defer conn.Close()
+	client := connect()
+	defer disconnect()
 
 	res, err := client.DeleteSession(context.Background(), &pb.DeleteSessionRequest{
 		Count:  int32(s.Args.Count),


### PR DESCRIPTION
* Fix an incorrect RPC call while executing `disassociate` command.
* Close gRPC connections after RPC has been performed.